### PR TITLE
Replace asdf with mise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use official Ubuntu image
+FROM ubuntu:latest
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal dependencies
+RUN apt-get update && apt-get install -y \
+    sudo \
+    curl \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash user && \
+    echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user
+
+# Copy start.sh
+COPY start.sh /home/user/start.sh
+RUN chmod +x /home/user/start.sh
+
+# Set working directory and user
+WORKDIR /home/user
+USER user
+
+# Set entrypoint
+ENTRYPOINT ["/home/user/start.sh"]

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@
     cd .dotfiles_public
     ./start.sh
     ```
+
+### Ubuntuでの検証
+Ubuntuでの検証は以下のコマンドを実行。
+
+```bash
+docker build -t dotfiles-test .
+docker run -it dotfiles-test
+```

--- a/asdfrc
+++ b/asdfrc
@@ -1,1 +1,0 @@
-legacy_version_file = yes

--- a/bash_profile
+++ b/bash_profile
@@ -36,6 +36,7 @@ if [ "$(uname)" == 'Darwin' ]; then
 elif [ "$(uname)" == 'Linux' ]; then
   [[ -r "/usr/share/bash-completion/bash_completion" ]] && . "/usr/share/bash-completion/bash_completion"
 fi
+
 # mise
 # https://mise.jdx.dev/getting-started.html#_2-activate-mise
 eval "$($HOME/.local/bin/mise activate bash)"

--- a/bash_profile
+++ b/bash_profile
@@ -48,3 +48,6 @@ fi
 
 # bash-completion(mac)
 [[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"
+
+# mise
+eval "$($HOME/.local/bin/mise activate bash)"

--- a/bash_profile
+++ b/bash_profile
@@ -25,30 +25,17 @@ if [ -d .cargo/bin ]; then
   export PATH=$PATH:$HOME/.cargo/bin
 fi
 
-# direnv
-export EDITOR=code
-eval "$(direnv hook bash)"
-
-# asdf
-if [ -d $HOME/.asdf/ ]; then
-  PATH=$HOME/.asdf/shims:$PATH
-  . $(brew --prefix asdf)/libexec/asdf.sh
-fi
-
-# java
-if [ -f ~/.asdf/plugins/java/set-java-home.bash ]; then
-  source ~/.asdf/plugins/java/set-java-home.bash
-fi
-
 # starship
 if [ -x "$(command -v starship)" ]; then
   eval "$(starship init bash)"
   starship preset pastel-powerline -o ~/.config/starship.toml
 fi
 
-# bash-completion(mac)
-[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"
-
+if [ "$(uname)" == 'Darwin' ]; then
+  [[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"
+elif [ "$(uname)" == 'Linux' ]; then
+  [[ -r "/usr/share/bash-completion/bash_completion" ]] && . "/usr/share/bash-completion/bash_completion"
+fi
 # mise
 # https://mise.jdx.dev/getting-started.html#_2-activate-mise
 eval "$($HOME/.local/bin/mise activate bash)"

--- a/bash_profile
+++ b/bash_profile
@@ -50,4 +50,5 @@ fi
 [[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"
 
 # mise
+# https://mise.jdx.dev/getting-started.html#_2-activate-mise
 eval "$($HOME/.local/bin/mise activate bash)"

--- a/start.sh
+++ b/start.sh
@@ -7,13 +7,13 @@ ln -s $HOME/.dotfiles_public/bash_profile $HOME/.bash_profile
 
 # If brew installed
 if [ -x "$(command -v brew)" ]; then
-  brew install curl git jq openssl tmux
+  brew install curl git jq openssl tmux bash-completion@2
   # nerd font
   brew install font-hack-nerd-font
 # If apt available
 elif [ -x "$(command -v apt)" ]; then
   sudo apt update -y
-  sudo apt install -y git jq openssl tmux
+  sudo apt install -y git jq openssl tmux bash-completion
   # nerd font
   FONT=FiraCode.tar.xz
   curl -fsSL https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/$FONT -o ~/.local/share/fonts/$FONT \

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,7 @@
-rm $HOME/.gitconfig $HOME/.gitignore_global $HOME/.tmux.conf $HOME/.asdfrc $HOME/.bash_profile
+rm $HOME/.gitconfig $HOME/.gitignore_global $HOME/.tmux.conf $HOME/.bash_profile
 ln -s $HOME/.dotfiles_public/gitconfig $HOME/.gitconfig
 ln -s $HOME/.dotfiles_public/gitignore_global $HOME/.gitignore_global
 ln -s $HOME/.dotfiles_public/tmux.conf $HOME/.tmux.conf
-ln -s $HOME/.dotfiles_public/asdfrc $HOME/.asdfrc
 ln -s $HOME/.dotfiles_public/bash_profile $HOME/.bash_profile
 
 # If brew installed
@@ -31,5 +30,11 @@ curl -sS https://starship.rs/install.sh | sh
 curl https://mise.run | sh
 eval "$($HOME/.local/bin/mise activate bash)"
 mise use -g usage
-mise completion bash --include-bash-completion-lib > /opt/homebrew/etc/bash_completion.d/mise
 
+if [ "$(uname)" == 'Darwin' ]; then
+  COMPLETION_DIR="$HOMEBREW_PREFIX/etc/bash_completion.d"
+else
+  COMPLETION_DIR="/etc/bash_completion.d"
+fi
+sudo mkdir -p "$COMPLETION_DIR"
+mise completion bash --include-bash-completion-lib | sudo tee "$COMPLETION_DIR/mise" > /dev/null

--- a/start.sh
+++ b/start.sh
@@ -7,13 +7,13 @@ ln -s $HOME/.dotfiles_public/bash_profile $HOME/.bash_profile
 
 # If brew installed
 if [ -x "$(command -v brew)" ]; then
-  brew install curl direnv git jq openssl tmux
+  brew install curl git jq openssl tmux
   # nerd font
   brew install font-hack-nerd-font
 # If apt available
 elif [ -x "$(command -v apt)" ]; then
   sudo apt update -y
-  sudo apt install -y direnv git jq openssl tmux
+  sudo apt install -y git jq openssl tmux
   # nerd font
   FONT=FiraCode.tar.xz
   curl -fsSL https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/$FONT -o ~/.local/share/fonts/$FONT \
@@ -27,11 +27,9 @@ fi
 # Install starship
 curl -sS https://starship.rs/install.sh | sh
 
-# Install asdf
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-PATH=$PATH:$HOME/.asdf/bin
+# Install mise
+curl https://mise.run | sh
+eval "$($HOME/.local/bin/mise activate bash)"
+mise use -g usage
+mise completion bash --include-bash-completion-lib > /opt/homebrew/etc/bash_completion.d/mise
 
-asdf plugin add nodejs
-asdf plugin add ruby
-asdf plugin add python
-asdf plugin add golang

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,11 @@ fi
 
 # If brew installed
 if [ -x "$(command -v brew)" ]; then
-  brew install curl git jq openssl tmux bash-completion@2
+  brew install curl git jq openssl tmux bash bash-completion@2
+  # macの標準bashは古いのでchshで変更する
+  # brewで入れたbashは標準ではないので/etc/shellsに追加する
+  echo "/opt/homebrew/bin/bash" | sudo tee -a /etc/shells
+  chsh -s /opt/homebrew/bin/bash
   # nerd font
   brew install font-hack-nerd-font
 # If apt available
@@ -57,4 +61,6 @@ else
   COMPLETION_DIR="/etc/bash_completion.d"
 fi
 mkdir -p "$COMPLETION_DIR"
-mise completion bash --include-bash-completion-lib | tee "$COMPLETION_DIR/mise" > /dev/null
+# bash-completionでmiseも補完させたいところだが、シェルの初期化時にハングしてしまうのでTODOとして残しておく
+# TODO: miseの補完をbash-completionに追加し、macでシェルがハングしないことを確認する
+# mise completion bash --include-bash-completion-lib | tee "$COMPLETION_DIR/mise" > /dev/null


### PR DESCRIPTION
CodeRabbit should be able to summarize this PR for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated the `mise` tool into the bash environment.
	- Introduced conditional logic for loading bash completion scripts based on the operating system.
	- Added instructions for verifying setup on Ubuntu in the README.

- **Chores**
	- Updated package installation commands for Homebrew and APT.
	- Removed `direnv` from package installations.
	- Added `bash-completion@2` and `bash-completion` packages.

- **Configuration**
	- Configured `mise` activation and bash completion.
	- Removed legacy versioning support in configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->